### PR TITLE
adding avx2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXXFLAGS = -std=c++11
 
 OBJS = main.o naive.o lookup.o lemire-sse.o lemire-neon.o  \
 	   range-sse.o range-neon.o range2-sse.o range2-neon.o \
-	   range-avx2.o
+	   lemire-avx2.o range-avx2.o
 
 utf8: ${OBJS}
 	gcc $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CXX = g++
 CPPFLAGS = -g -O3 -Wall -march=native
 CXXFLAGS = -std=c++11
 
-OBJS = main.o naive.o lookup.o lemire-sse.o lemire-neon.o \
-	   range-sse.o range-neon.o range2-sse.o range2-neon.o
+OBJS = main.o naive.o lookup.o lemire-sse.o lemire-neon.o  \
+	   range-sse.o range-neon.o range2-sse.o range2-neon.o \
+	   range-avx2.o
 
 utf8: ${OBJS}
 	gcc $^ -o $@

--- a/lemire-avx2.c
+++ b/lemire-avx2.c
@@ -1,0 +1,233 @@
+// Adapted from https://github.com/lemire/fastvalidate-utf-8
+
+#ifdef __AVX2__
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <x86intrin.h>
+
+/*
+ * legal utf-8 byte sequence
+ * http://www.unicode.org/versions/Unicode6.0.0/ch03.pdf - page 94
+ *
+ *  Code Points        1st       2s       3s       4s
+ * U+0000..U+007F     00..7F
+ * U+0080..U+07FF     C2..DF   80..BF
+ * U+0800..U+0FFF     E0       A0..BF   80..BF
+ * U+1000..U+CFFF     E1..EC   80..BF   80..BF
+ * U+D000..U+D7FF     ED       80..9F   80..BF
+ * U+E000..U+FFFF     EE..EF   80..BF   80..BF
+ * U+10000..U+3FFFF   F0       90..BF   80..BF   80..BF
+ * U+40000..U+FFFFF   F1..F3   80..BF   80..BF   80..BF
+ * U+100000..U+10FFFF F4       80..8F   80..BF   80..BF
+ *
+ */
+
+#if 0
+static void print256(const char *s, const __m256i v256)
+{
+  const unsigned char *v8 = (const unsigned char *)&v256;
+  if (s)
+    printf("%s:\t", s);
+  for (int i = 0; i < 32; i++)
+    printf("%02x ", v8[i]);
+  printf("\n");
+}
+#endif
+
+static inline __m256i push_last_byte_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 15);
+}
+
+static inline __m256i push_last_2bytes_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 14);
+}
+
+// all byte values must be no larger than 0xF4
+static inline void avxcheckSmallerThan0xF4(__m256i current_bytes,
+                                           __m256i *has_error) {
+  // unsigned, saturates to 0 below max
+  *has_error = _mm256_or_si256(
+      *has_error, _mm256_subs_epu8(current_bytes, _mm256_set1_epi8(0xF4)));
+}
+
+static inline __m256i avxcontinuationLengths(__m256i high_nibbles) {
+  return _mm256_shuffle_epi8(
+      _mm256_setr_epi8(1, 1, 1, 1, 1, 1, 1, 1, // 0xxx (ASCII)
+                       0, 0, 0, 0,             // 10xx (continuation)
+                       2, 2,                   // 110x
+                       3,                      // 1110
+                       4, // 1111, next should be 0 (not checked here)
+                       1, 1, 1, 1, 1, 1, 1, 1, // 0xxx (ASCII)
+                       0, 0, 0, 0,             // 10xx (continuation)
+                       2, 2,                   // 110x
+                       3,                      // 1110
+                       4 // 1111, next should be 0 (not checked here)
+                       ),
+      high_nibbles);
+}
+
+static inline __m256i avxcarryContinuations(__m256i initial_lengths,
+                                            __m256i previous_carries) {
+
+  __m256i right1 = _mm256_subs_epu8(
+      push_last_byte_of_a_to_b(previous_carries, initial_lengths),
+      _mm256_set1_epi8(1));
+  __m256i sum = _mm256_add_epi8(initial_lengths, right1);
+
+  __m256i right2 = _mm256_subs_epu8(
+      push_last_2bytes_of_a_to_b(previous_carries, sum), _mm256_set1_epi8(2));
+  return _mm256_add_epi8(sum, right2);
+}
+
+static inline void avxcheckContinuations(__m256i initial_lengths,
+                                         __m256i carries, __m256i *has_error) {
+
+  // overlap || underlap
+  // carry > length && length > 0 || !(carry > length) && !(length > 0)
+  // (carries > length) == (lengths > 0)
+  __m256i overunder = _mm256_cmpeq_epi8(
+      _mm256_cmpgt_epi8(carries, initial_lengths),
+      _mm256_cmpgt_epi8(initial_lengths, _mm256_setzero_si256()));
+
+  *has_error = _mm256_or_si256(*has_error, overunder);
+}
+
+// when 0xED is found, next byte must be no larger than 0x9F
+// when 0xF4 is found, next byte must be no larger than 0x8F
+// next byte must be continuation, ie sign bit is set, so signed < is ok
+static inline void avxcheckFirstContinuationMax(__m256i current_bytes,
+                                                __m256i off1_current_bytes,
+                                                __m256i *has_error) {
+  __m256i maskED =
+      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xED));
+  __m256i maskF4 =
+      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xF4));
+
+  __m256i badfollowED = _mm256_and_si256(
+      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x9F)), maskED);
+  __m256i badfollowF4 = _mm256_and_si256(
+      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x8F)), maskF4);
+
+  *has_error =
+      _mm256_or_si256(*has_error, _mm256_or_si256(badfollowED, badfollowF4));
+}
+
+// map off1_hibits => error condition
+// hibits     off1    cur
+// C       => < C2 && true
+// E       => < E1 && < A0
+// F       => < F1 && < 90
+// else      false && false
+static inline void avxcheckOverlong(__m256i current_bytes,
+                                    __m256i off1_current_bytes, __m256i hibits,
+                                    __m256i previous_hibits,
+                                    __m256i *has_error) {
+  __m256i off1_hibits = push_last_byte_of_a_to_b(previous_hibits, hibits);
+  __m256i initial_mins = _mm256_shuffle_epi8(
+      _mm256_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128, -128, -128, // 10xx => false
+                       0xC2, -128,       // 110x
+                       0xE1,             // 1110
+                       0xF1, -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128, -128, -128, -128, // 10xx => false
+                       0xC2, -128,             // 110x
+                       0xE1,                   // 1110
+                       0xF1),
+      off1_hibits);
+
+  __m256i initial_under = _mm256_cmpgt_epi8(initial_mins, off1_current_bytes);
+
+  __m256i second_mins = _mm256_shuffle_epi8(
+      _mm256_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128, -128, -128, // 10xx => false
+                       127, 127,         // 110x => true
+                       0xA0,             // 1110
+                       0x90, -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128, -128, -128, -128, // 10xx => false
+                       127, 127,               // 110x => true
+                       0xA0,                   // 1110
+                       0x90),
+      off1_hibits);
+  __m256i second_under = _mm256_cmpgt_epi8(second_mins, current_bytes);
+  *has_error = _mm256_or_si256(*has_error,
+                               _mm256_and_si256(initial_under, second_under));
+}
+
+struct avx_processed_utf_bytes {
+  __m256i rawbytes;
+  __m256i high_nibbles;
+  __m256i carried_continuations;
+};
+
+static inline void avx_count_nibbles(__m256i bytes,
+                                     struct avx_processed_utf_bytes *answer) {
+  answer->rawbytes = bytes;
+  answer->high_nibbles =
+      _mm256_and_si256(_mm256_srli_epi16(bytes, 4), _mm256_set1_epi8(0x0F));
+}
+
+// check whether the current bytes are valid UTF-8
+// at the end of the function, previous gets updated
+static struct avx_processed_utf_bytes
+avxcheckUTF8Bytes(__m256i current_bytes,
+                  struct avx_processed_utf_bytes *previous,
+                  __m256i *has_error) {
+  struct avx_processed_utf_bytes pb;
+  avx_count_nibbles(current_bytes, &pb);
+
+  avxcheckSmallerThan0xF4(current_bytes, has_error);
+
+  __m256i initial_lengths = avxcontinuationLengths(pb.high_nibbles);
+
+  pb.carried_continuations =
+      avxcarryContinuations(initial_lengths, previous->carried_continuations);
+
+  avxcheckContinuations(initial_lengths, pb.carried_continuations, has_error);
+
+  __m256i off1_current_bytes =
+      push_last_byte_of_a_to_b(previous->rawbytes, pb.rawbytes);
+  avxcheckFirstContinuationMax(current_bytes, off1_current_bytes, has_error);
+
+  avxcheckOverlong(current_bytes, off1_current_bytes, pb.high_nibbles,
+                   previous->high_nibbles, has_error);
+  return pb;
+}
+
+/* Return 0 on success, -1 on error */
+int utf8_lemire_avx2(const unsigned char *src, int len) {
+  size_t i = 0;
+  __m256i has_error = _mm256_setzero_si256();
+  struct avx_processed_utf_bytes previous = {
+      .rawbytes = _mm256_setzero_si256(),
+      .high_nibbles = _mm256_setzero_si256(),
+      .carried_continuations = _mm256_setzero_si256()};
+  if (len >= 32) {
+    for (; i <= len - 32; i += 32) {
+      __m256i current_bytes = _mm256_loadu_si256((const __m256i *)(src + i));
+      previous = avxcheckUTF8Bytes(current_bytes, &previous, &has_error);
+    }
+  }
+
+  // last part
+  if (i < len) {
+    char buffer[32];
+    memset(buffer, 0, 32);
+    memcpy(buffer, src + i, len - i);
+    __m256i current_bytes = _mm256_loadu_si256((const __m256i *)(buffer));
+    previous = avxcheckUTF8Bytes(current_bytes, &previous, &has_error);
+  } else {
+    has_error = _mm256_or_si256(
+        _mm256_cmpgt_epi8(previous.carried_continuations,
+                          _mm256_setr_epi8(9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+                                           9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+                                           9, 9, 9, 9, 9, 9, 9, 1)),
+        has_error);
+  }
+
+  return _mm256_testz_si256(has_error, has_error) ? 0 : -1;
+}
+
+#endif

--- a/main.c
+++ b/main.c
@@ -14,6 +14,9 @@ int utf8_boost(const unsigned char *data, int len);
 int utf8_lemire(const unsigned char *data, int len);
 int utf8_range(const unsigned char *data, int len);
 int utf8_range2(const unsigned char *data, int len);
+#ifdef __AVX2__
+int utf8_range_avx2(const unsigned char *data, int len);
+#endif
 
 static struct ftab {
     const char *name;
@@ -39,6 +42,12 @@ static struct ftab {
         .name = "range2",
         .func = utf8_range2,
     },
+#ifdef __AVX2__
+    {
+        .name = "range_avx2",
+        .func = utf8_range_avx2,
+    },
+#endif
 #ifdef BOOST
     {
         .name = "boost",
@@ -89,6 +98,10 @@ static unsigned char *load_test_file(int *len)
         printf("Failed to read file!\n");
         exit(1);
     }
+
+    
+    utf8_range(data, *len);
+    utf8_range_avx2(data, *len);
 
     close(fd);
 

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@ int utf8_lemire(const unsigned char *data, int len);
 int utf8_range(const unsigned char *data, int len);
 int utf8_range2(const unsigned char *data, int len);
 #ifdef __AVX2__
+int utf8_lemire_avx2(const unsigned char *data, int len);
 int utf8_range_avx2(const unsigned char *data, int len);
 #endif
 
@@ -43,6 +44,10 @@ static struct ftab {
         .func = utf8_range2,
     },
 #ifdef __AVX2__
+    {
+        .name = "lemire_avx2",
+        .func = utf8_range_avx2,
+    },
     {
         .name = "range_avx2",
         .func = utf8_range_avx2,

--- a/range-avx2.c
+++ b/range-avx2.c
@@ -1,0 +1,273 @@
+#ifdef __AVX2__
+
+#include <stdio.h>
+#include <stdint.h>
+#include <x86intrin.h>
+
+int utf8_naive(const unsigned char *data, int len);
+
+#if 0
+static void print256(const char *s, const __m256i v256)
+{
+  const unsigned char *v8 = (const unsigned char *)&v256;
+  if (s)
+    printf("%s:\t", s);
+  for (int i = 0; i < 32; i++)
+    printf("%02x ", v8[i]);
+  printf("\n");
+}
+#endif
+
+/*
+ * Map high nibble of "First Byte" to legal character length minus 1
+ * 0x00 ~ 0xBF --> 0
+ * 0xC0 ~ 0xDF --> 1
+ * 0xE0 ~ 0xEF --> 2
+ * 0xF0 ~ 0xFF --> 3
+ */
+static const int8_t _first_len_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
+};
+
+/* Map "First Byte" to 8-th item of range table (0xC2 ~ 0xF4) */
+static const int8_t _first_range_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8,
+};
+
+/*
+ * Range table, map range index to min and max values
+ * Index 0    : 00 ~ 7F (First Byte, ascii)
+ * Index 1,2,3: 80 ~ BF (Second, Third, Fourth Byte)
+ * Index 4    : A0 ~ BF (Second Byte after E0)
+ * Index 5    : 80 ~ 9F (Second Byte after ED)
+ * Index 6    : 90 ~ BF (Second Byte after F0)
+ * Index 7    : 80 ~ 8F (Second Byte after F4)
+ * Index 8    : C2 ~ F4 (First Byte, non ascii)
+ * Index 9~15 : illegal: i >= 127 && i <= -128
+ */
+static const int8_t _range_min_tbl[] = {
+    0x00, 0x80, 0x80, 0x80, 0xA0, 0x80, 0x90, 0x80,
+    0xC2, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F,
+    0x00, 0x80, 0x80, 0x80, 0xA0, 0x80, 0x90, 0x80,
+    0xC2, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F,
+};
+static const int8_t _range_max_tbl[] = {
+    0x7F, 0xBF, 0xBF, 0xBF, 0xBF, 0x9F, 0xBF, 0x8F,
+    0xF4, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+    0x7F, 0xBF, 0xBF, 0xBF, 0xBF, 0x9F, 0xBF, 0x8F,
+    0xF4, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+};
+
+/*
+ * Tables for fast handling of four special First Bytes(E0,ED,F0,F4), after
+ * which the Second Byte are not 80~BF. It contains "range index adjustment".
+ * +------------+---------------+------------------+----------------+
+ * | First Byte | original range| range adjustment | adjusted range |
+ * +------------+---------------+------------------+----------------+
+ * | E0         | 2             | 2                | 4              |
+ * +------------+---------------+------------------+----------------+
+ * | ED         | 2             | 3                | 5              |
+ * +------------+---------------+------------------+----------------+
+ * | F0         | 3             | 3                | 6              |
+ * +------------+---------------+------------------+----------------+
+ * | F4         | 4             | 4                | 8              |
+ * +------------+---------------+------------------+----------------+
+ */
+/* index1 -> E0, index14 -> ED */
+static const int8_t _df_ee_tbl[] = {
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+};
+/* index1 -> F0, index5 -> F4 */
+static const int8_t _ef_fe_tbl[] = {
+    0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+#define RET_ERR_IDX 0   /* Define 1 to return index of first error char */
+
+static inline __m256i push_last_byte_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 15);
+}
+
+static inline __m256i push_last_2bytes_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 14);
+}
+
+static inline __m256i push_last_3bytes_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 13);
+}
+
+/* 5x faster than naive method */
+/* Return 0 - success, -1 - error, >0 - first error char(if RET_ERR_IDX = 1) */
+int utf8_range_avx2(const unsigned char *data, int len)
+{
+#if  RET_ERR_IDX
+    int err_pos = 1;
+#endif
+
+    if (len >= 32) {
+        __m256i prev_input = _mm256_set1_epi8(0);
+        __m256i prev_first_len = _mm256_set1_epi8(0);
+
+        /* Cached tables */
+        const __m256i first_len_tbl =
+            _mm256_lddqu_si256((const __m256i *)_first_len_tbl);
+        const __m256i first_range_tbl =
+            _mm256_lddqu_si256((const __m256i *)_first_range_tbl);
+        const __m256i range_min_tbl =
+            _mm256_lddqu_si256((const __m256i *)_range_min_tbl);
+        const __m256i range_max_tbl =
+            _mm256_lddqu_si256((const __m256i *)_range_max_tbl);
+        const __m256i df_ee_tbl =
+            _mm256_lddqu_si256((const __m256i *)_df_ee_tbl);
+        const __m256i ef_fe_tbl =
+            _mm256_lddqu_si256((const __m256i *)_ef_fe_tbl);
+
+        __m256i error = _mm256_set1_epi8(0);
+
+        while (len >= 32) {
+            const __m256i input = _mm256_lddqu_si256((const __m256i *)data);
+
+            /* high_nibbles = input >> 4 */
+            const __m256i high_nibbles =
+                _mm256_and_si256(_mm256_srli_epi16(input, 4), _mm256_set1_epi8(0x0F));
+
+            /* first_len = legal character length minus 1 */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* first_len = first_len_tbl[high_nibbles] */
+            __m256i first_len = _mm256_shuffle_epi8(first_len_tbl, high_nibbles);
+
+            /* First Byte: set range index to 8 for bytes within 0xC0 ~ 0xFF */
+            /* range = first_range_tbl[high_nibbles] */
+            __m256i range = _mm256_shuffle_epi8(first_range_tbl, high_nibbles);
+
+            /* Second Byte: set range index to first_len */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* range |= (first_len, prev_first_len) << 1 byte */
+            range = _mm256_or_si256(
+                    range, push_last_byte_of_a_to_b(prev_first_len, first_len));
+
+            /* Third Byte: set range index to saturate_sub(first_len, 1) */
+            /* 0 for 00~7F, 0 for C0~DF, 1 for E0~EF, 2 for F0~FF */
+            __m256i tmp1, tmp2;
+ 
+            /* tmp1 = saturate_sub(first_len, 1) */
+            tmp1 = _mm256_subs_epu8(first_len, _mm256_set1_epi8(1));
+            /* tmp2 = saturate_sub(prev_first_len, 1) */
+            tmp2 = _mm256_subs_epu8(prev_first_len, _mm256_set1_epi8(1));
+   
+            /* range |= (tmp1, tmp2) << 2 bytes */
+            range = _mm256_or_si256(range, push_last_2bytes_of_a_to_b(tmp2, tmp1));
+
+            /* Fourth Byte: set range index to saturate_sub(first_len, 2) */
+            /* 0 for 00~7F, 0 for C0~DF, 0 for E0~EF, 1 for F0~FF */
+            /* tmp1 = saturate_sub(first_len, 2) */
+            tmp1 = _mm256_subs_epu8(first_len, _mm256_set1_epi8(2));
+            /* tmp2 = saturate_sub(prev_first_len, 2) */
+            tmp2 = _mm256_subs_epu8(prev_first_len, _mm256_set1_epi8(2));
+            /* range |= (tmp1, tmp2) << 3 bytes */
+            range = _mm256_or_si256(range, push_last_3bytes_of_a_to_b(tmp2, tmp1));
+
+            /*
+             * Now we have below range indices caluclated
+             * Correct cases:
+             * - 8 for C0~FF
+             * - 3 for 1st byte after F0~FF
+             * - 2 for 1st byte after E0~EF or 2nd byte after F0~FF
+             * - 1 for 1st byte after C0~DF or 2nd byte after E0~EF or
+             *         3rd byte after F0~FF
+             * - 0 for others
+             * Error cases:
+             *   9,10,11 if non ascii First Byte overlaps
+             *   E.g., F1 80 C2 90 --> 8 3 10 2, where 10 indicates error
+             */
+
+            /* Adjust Second Byte range for special First Bytes(E0,ED,F0,F4) */
+            /* Overlaps lead to index 9~15, which are illegal in range table */
+            __m256i shift1, pos, range2;
+            /* shift1 = (input, prev_input) << 1 byte */
+            shift1 = push_last_byte_of_a_to_b(prev_input, input);
+            pos = _mm256_sub_epi8(shift1, _mm256_set1_epi8(0xEF));
+            /*
+             * shift1:  | EF  F0 ... FE | FF  00  ... ...  DE | DF  E0 ... EE |
+             * pos:     | 0   1      15 | 16  17           239| 240 241    255|
+             * pos-240: | 0   0      0  | 0   0            0  | 0   1      15 |
+             * pos+112: | 112 113    127|       >= 128        |     >= 128    |
+             */
+            tmp1 = _mm256_subs_epu8(pos, _mm256_set1_epi8(240));
+            range2 = _mm256_shuffle_epi8(df_ee_tbl, tmp1);
+            tmp2 = _mm256_adds_epu8(pos, _mm256_set1_epi8(112));
+            range2 = _mm256_add_epi8(range2, _mm256_shuffle_epi8(ef_fe_tbl, tmp2));
+
+            range = _mm256_add_epi8(range, range2);
+
+            /* Load min and max values per calculated range index */
+            __m256i minv = _mm256_shuffle_epi8(range_min_tbl, range);
+            __m256i maxv = _mm256_shuffle_epi8(range_max_tbl, range);
+
+            /* Check value range */
+#if RET_ERR_IDX
+            error = _mm256_cmpgt_epi8(minv, input);
+            error = _mm256_or_si256(error, _mm256_cmpgt_epi8(input, maxv));
+            /* 5% performance drop from this conditional branch */
+            if (!_mm256_testz_si256(error, error))
+                break;
+#else
+            error = _mm256_or_si256(error, _mm256_cmpgt_epi8(minv, input));
+            error = _mm256_or_si256(error, _mm256_cmpgt_epi8(input, maxv));
+#endif
+
+            prev_input = input;
+            prev_first_len = first_len;
+
+            data += 32;
+            len -= 32;
+#if RET_ERR_IDX
+            err_pos += 32;
+#endif
+        }
+
+#if RET_ERR_IDX
+        /* Error in first 16 bytes */
+        if (err_pos == 1)
+            goto do_naive;
+#else
+        if (!_mm256_testz_si256(error, error))
+            return -1;
+#endif
+
+        /* Find previous token (not 80~BF) */
+        int32_t token4 = _mm256_extract_epi32(prev_input, 7);
+        const int8_t *token = (const int8_t *)&token4;
+        int lookahead = 0;
+        if (token[3] > (int8_t)0xBF)
+            lookahead = 1;
+        else if (token[2] > (int8_t)0xBF)
+            lookahead = 2;
+        else if (token[1] > (int8_t)0xBF)
+            lookahead = 3;
+
+        data -= lookahead;
+        len += lookahead;
+#if RET_ERR_IDX
+        err_pos -= lookahead;
+#endif
+    }
+
+    /* Check remaining bytes with naive method */
+#if RET_ERR_IDX
+    int err_pos2;
+do_naive:
+    err_pos2 = utf8_naive(data, len);
+    if (err_pos2)
+        return err_pos + err_pos2 - 1;
+    return 0;
+#else
+    return utf8_naive(data, len);
+#endif
+}
+
+#endif


### PR DESCRIPTION
Hi!
I've ported ported range to avx2 and added lemire_avx2. Here are my results:
=============== Bench UTF8 (14058 bytes) ===============
bench naive... pass
time: 1.2629 s
data: 1024 MB
BW: 810.81 MB/s

bench lookup... pass
time: 3.0372 s
data: 1024 MB
BW: 337.15 MB/s

bench lemire... pass
time: 0.2330 s
data: 1024 MB
BW: 4395.50 MB/s

bench range... pass
time: 0.2126 s
data: 1024 MB
BW: 4817.08 MB/s

bench range2... pass
time: 0.2125 s
data: 1024 MB
BW: 4819.16 MB/s

bench lemire_avx2... pass
time: 0.1490 s
data: 1024 MB
BW: 6870.18 MB/s

bench range_avx2... pass
time: 0.1490 s
data: 1024 MB
BW: 6870.88 MB/s


I've also plugged the range algorithm to simdjson. The results are not those expected. In fact we get the best performances on sse.
[sse](https://github.com/lemire/simdjson/pull/279)
[avx2](https://github.com/lemire/simdjson/pull/286)
[neon](https://github.com/lemire/simdjson/pull/282)