### PR TITLE
NEON optimizations for range/range2

### DIFF
--- a/main.c
+++ b/main.c
@@ -104,10 +104,10 @@ static unsigned char *load_test_file(int *len)
         exit(1);
     }
 
-    
     utf8_range(data, *len);
+#ifdef __AVX2__
     utf8_range_avx2(data, *len);
-
+#endif
     close(fd);
 
     return data;

--- a/range2-neon.c
+++ b/range2-neon.c
@@ -59,65 +59,65 @@ int utf8_range2(const unsigned char *data, int len)
 
             /* Forces a double load on Clang */
             const uint8x16x2_t input_pair = vld1q_u8_x2(data);
-            const uint8x16_t input = input_pair.val[0];
-            const uint8x16_t _input = input_pair.val[1];
+            const uint8x16_t input_a = input_pair.val[0];
+            const uint8x16_t input_b = input_pair.val[1];
 
-            const uint8x16_t high_nibbles = vshrq_n_u8(input, 4);
-            const uint8x16_t _high_nibbles = vshrq_n_u8(_input, 4);
+            const uint8x16_t high_nibbles_a = vshrq_n_u8(input_a, 4);
+            const uint8x16_t high_nibbles_b = vshrq_n_u8(input_b, 4);
 
-            const uint8x16_t first_len =
-                vqtbl1q_u8(first_len_tbl, high_nibbles);
-            const uint8x16_t _first_len =
-                vqtbl1q_u8(first_len_tbl, _high_nibbles);
+            const uint8x16_t first_len_a =
+                vqtbl1q_u8(first_len_tbl, high_nibbles_a);
+            const uint8x16_t first_len_b =
+                vqtbl1q_u8(first_len_tbl, high_nibbles_b);
 
-            uint8x16_t range = vqtbl1q_u8(first_range_tbl, high_nibbles);
-            uint8x16_t _range = vqtbl1q_u8(first_range_tbl, _high_nibbles);
+            uint8x16_t range_a = vqtbl1q_u8(first_range_tbl, high_nibbles_a);
+            uint8x16_t range_b = vqtbl1q_u8(first_range_tbl, high_nibbles_b);
 
-            range =
-                vorrq_u8(range, vextq_u8(prev_first_len, first_len, 15));
-            _range =
-                vorrq_u8(_range, vextq_u8(first_len, _first_len, 15));
+            range_a =
+                vorrq_u8(range_a, vextq_u8(prev_first_len, first_len_a, 15));
+            range_b =
+                vorrq_u8(range_b, vextq_u8(first_len_a, first_len_b, 15));
 
-            uint8x16_t tmp1, tmp2, _tmp1, _tmp2;
-            tmp1 = vextq_u8(prev_first_len, first_len, 14);
-            tmp1 = vqsubq_u8(tmp1, const_1);
-            range = vorrq_u8(range, tmp1);
+            uint8x16_t tmp1_a, tmp2_a, tmp1_b, tmp2_b;
+            tmp1_a = vextq_u8(prev_first_len, first_len_a, 14);
+            tmp1_a = vqsubq_u8(tmp1_a, const_1);
+            range_a = vorrq_u8(range_a, tmp1_a);
 
-            _tmp1 = vextq_u8(first_len, _first_len, 14);
-            _tmp1 = vqsubq_u8(_tmp1, const_1);
-            _range = vorrq_u8(_range, _tmp1);
+            tmp1_b = vextq_u8(first_len_a, first_len_b, 14);
+            tmp1_b = vqsubq_u8(tmp1_b, const_1);
+            range_b = vorrq_u8(range_b, tmp1_b);
 
-            tmp2 = vextq_u8(prev_first_len, first_len, 13);
-            tmp2 = vqsubq_u8(tmp2, const_2);
-            range = vorrq_u8(range, tmp2);
+            tmp2_a = vextq_u8(prev_first_len, first_len_a, 13);
+            tmp2_a = vqsubq_u8(tmp2_a, const_2);
+            range_a = vorrq_u8(range_a, tmp2_a);
 
-            _tmp2 = vextq_u8(first_len, _first_len, 13);
-            _tmp2 = vqsubq_u8(_tmp2, const_2);
-            _range = vorrq_u8(_range, _tmp2);
+            tmp2_b = vextq_u8(first_len_a, first_len_b, 13);
+            tmp2_b = vqsubq_u8(tmp2_b, const_2);
+            range_b = vorrq_u8(range_b, tmp2_b);
 
-            uint8x16_t shift1 = vextq_u8(prev_input, input, 15);
-            uint8x16_t pos = vsubq_u8(shift1, const_e0);
-            range = vaddq_u8(range, vqtbl2q_u8(range_adjust_tbl, pos));
+            uint8x16_t shift1_a = vextq_u8(prev_input, input_a, 15);
+            uint8x16_t pos_a = vsubq_u8(shift1_a, const_e0);
+            range_a = vaddq_u8(range_a, vqtbl2q_u8(range_adjust_tbl, pos_a));
 
-            uint8x16_t _shift1 = vextq_u8(input, _input, 15);
-            uint8x16_t _pos = vsubq_u8(_shift1, const_e0);
-            _range = vaddq_u8(_range, vqtbl2q_u8(range_adjust_tbl, _pos));
+            uint8x16_t shift1_b = vextq_u8(input_a, input_b, 15);
+            uint8x16_t pos_b = vsubq_u8(shift1_b, const_e0);
+            range_b = vaddq_u8(range_b, vqtbl2q_u8(range_adjust_tbl, pos_b));
 
-            uint8x16_t minv = vqtbl1q_u8(range_min_tbl, range);
-            uint8x16_t maxv = vqtbl1q_u8(range_max_tbl, range);
+            uint8x16_t minv_a = vqtbl1q_u8(range_min_tbl, range_a);
+            uint8x16_t maxv_a = vqtbl1q_u8(range_max_tbl, range_a);
 
-            uint8x16_t _minv = vqtbl1q_u8(range_min_tbl, _range);
-            uint8x16_t _maxv = vqtbl1q_u8(range_max_tbl, _range);
+            uint8x16_t minv_b = vqtbl1q_u8(range_min_tbl, range_b);
+            uint8x16_t maxv_b = vqtbl1q_u8(range_max_tbl, range_b);
 
-            error1 = vorrq_u8(error1, vcltq_u8(input, minv));
-            error2 = vorrq_u8(error2, vcgtq_u8(input, maxv));
+            error1 = vorrq_u8(error1, vcltq_u8(input_a, minv_a));
+            error2 = vorrq_u8(error2, vcgtq_u8(input_a, maxv_a));
 
-            error3 = vorrq_u8(error3, vcltq_u8(_input, _minv));
-            error4 = vorrq_u8(error4, vcgtq_u8(_input, _maxv));
+            error3 = vorrq_u8(error3, vcltq_u8(input_b, minv_b));
+            error4 = vorrq_u8(error4, vcgtq_u8(input_b, maxv_b));
 
             /************************ next iteration *************************/
-            prev_input = _input;
-            prev_first_len = _first_len;
+            prev_input = input_b;
+            prev_first_len = first_len_b;
 
             data += 32;
             len -= 32;


### PR DESCRIPTION
It is very likely that these optimizations apply to the x86 side.

 - Split error counters, join at the end
   - Prevents `vqtbl1q`'s latency from stalling the loop.
 - Remove redundant `vqsubq`s
   - Merge `prev_first_len` and `first_len`, then saturate sub that.

Default benchmark, Clang 10.0.1, Google Pixel 2 XL (Snapdragon 835):
 - range: 1069 MB/s -> 1136 MB/s (6% speedup)
 - range2: 1202 MB/s -> 1267 MB/s (5% speedup) 

Also fixes a compilation error when compiled on non-AVX2 targets.